### PR TITLE
manifest: add GitHub notifications to ArgoCD applications

### DIFF
--- a/apps/base/buchubot.yaml
+++ b/apps/base/buchubot.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: buchubot
   namespace: argocd
   finalizers:

--- a/apps/base/discord-bots.yaml
+++ b/apps/base/discord-bots.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: discord-bots
   namespace: argocd
   finalizers:

--- a/apps/base/discordbot-pow.yaml
+++ b/apps/base/discordbot-pow.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: discordbot-pow
   namespace: argocd
   finalizers:

--- a/apps/base/gha-runner-controller.yaml
+++ b/apps/base/gha-runner-controller.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: gha-runner-controller
   namespace: argocd
   finalizers:

--- a/apps/base/hachimitsu-random-bot.yaml
+++ b/apps/base/hachimitsu-random-bot.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: hachimitsu-random-bot
   namespace: argocd
   finalizers:

--- a/apps/base/mmmm.yaml
+++ b/apps/base/mmmm.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: mmmm
   namespace: argocd
   finalizers:

--- a/apps/base/smee.yaml
+++ b/apps/base/smee.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: smee
   namespace: argocd
   finalizers:

--- a/apps/base/twibot-to-discord.yaml
+++ b/apps/base/twibot-to-discord.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: twibot-to-discord
   namespace: argocd
   finalizers:

--- a/system-apps/base/argo-cd.yaml
+++ b/system-apps/base/argo-cd.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: argo-cd
   namespace: argocd
 spec:

--- a/system-apps/base/k3s-upgrade.yaml
+++ b/system-apps/base/k3s-upgrade.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: k3s-upgrade
   namespace: argocd
   finalizers:

--- a/system-apps/base/oci-secrets.yaml
+++ b/system-apps/base/oci-secrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: oci-secrets
   namespace: argocd
 spec:

--- a/system-apps/base/sync-apps.yaml
+++ b/system-apps/base/sync-apps.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: sync-apps
   namespace: argocd
 spec:

--- a/system-apps/base/sync-projects.yaml
+++ b/system-apps/base/sync-projects.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.github: ""
   name: sync-projects
   namespace: argocd
 spec:


### PR DESCRIPTION
Add annotations for GitHub notifications to multiple ArgoCD application manifests.
This change enables deployment notifications to be sent to GitHub, improving visibility and tracking of application deployments.